### PR TITLE
Fix incorrect dependency tree for gdk-pixbuf

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -333,6 +333,7 @@ parts:
     - glib
     - gobject-introspection
     - libpng
+    - shared-mime-info
     source: https://download.gnome.org/sources/gdk-pixbuf/2.36/gdk-pixbuf-2.36.12.tar.xz
     source-checksum: sha256/fff85cf48223ab60e3c3c8318e2087131b590fd6f1737e42cb3759a3b427a334
     plugin: autotools


### PR DESCRIPTION
GDK-Pixbuf requires shared-mime-info.
* Add `after` on gdk-pixbuf to require  be built first.