### PR TITLE
Set necessary env for system gtk themes to work and clean up content     interfaces

### DIFF
--- a/patches/desktop-launch.patch
+++ b/patches/desktop-launch.patch
@@ -22,8 +22,8 @@ index ff0b5453..380c1c6c 100755
 -  ln -s "$SNAP_DESKTOP_RUNTIME"/usr/lib/"$ARCH"/gtk-3.0/3.0.0/immodules/*.so "$GTK_IM_MODULE_DIR"
 -  async_exec "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libgtk-3-0/gtk-query-immodules-3.0" > "$GTK_IM_MODULE_FILE"
 +  mkdir -p "$GTK_IM_MODULE_DIR" "$GTK3_IM_MODULE_DIR"
-+  ln -sf "$SNAP"/usr/lib/"$ARCH"/gtk-2.0/2.10.0/immodules/*.so "$GTK_IM_MODULE_DIR"
-+  ln -sf "$SNAP_DESKTOP_RUNTIME"/usr/lib/"$ARCH"/gtk-3.0/3.0.0/immodules/*.so "$GTK3_IM_MODULE_DIR"
++  ln -s "$SNAP"/usr/lib/"$ARCH"/gtk-2.0/2.10.0/immodules/*.so "$GTK_IM_MODULE_DIR"
++  ln -s "$SNAP_DESKTOP_RUNTIME"/usr/lib/"$ARCH"/gtk-3.0/3.0.0/immodules/*.so "$GTK3_IM_MODULE_DIR"
 +  async_exec "$SNAP/usr/lib/$ARCH/libgtk2.0-0/gtk-query-immodules-2.0" > "$GTK_IM_MODULE_FILE"
 +  async_exec "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libgtk-3-0/gtk-query-immodules-3.0" > "$GTK3_IM_MODULE_FILE"
  fi

--- a/patches/desktop-launch.patch
+++ b/patches/desktop-launch.patch
@@ -22,7 +22,7 @@ index ff0b5453..380c1c6c 100755
 -  ln -s "$SNAP_DESKTOP_RUNTIME"/usr/lib/"$ARCH"/gtk-3.0/3.0.0/immodules/*.so "$GTK_IM_MODULE_DIR"
 -  async_exec "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libgtk-3-0/gtk-query-immodules-3.0" > "$GTK_IM_MODULE_FILE"
 +  mkdir -p "$GTK_IM_MODULE_DIR" "$GTK3_IM_MODULE_DIR"
-+  ln -s "$SNAP"/usr/lib/"$ARCH"/gtk-2.0/2.10.0/immodules/*.so "$GTK_IM_MODULE_DIR"
++  ln -sf "$SNAP"/usr/lib/"$ARCH"/gtk-2.0/2.10.0/immodules/*.so "$GTK_IM_MODULE_DIR"
 +  ln -s "$SNAP_DESKTOP_RUNTIME"/usr/lib/"$ARCH"/gtk-3.0/3.0.0/immodules/*.so "$GTK3_IM_MODULE_DIR"
 +  async_exec "$SNAP/usr/lib/$ARCH/libgtk2.0-0/gtk-query-immodules-2.0" > "$GTK_IM_MODULE_FILE"
 +  async_exec "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libgtk-3-0/gtk-query-immodules-3.0" > "$GTK3_IM_MODULE_FILE"

--- a/patches/desktop-launch.patch
+++ b/patches/desktop-launch.patch
@@ -23,7 +23,7 @@ index ff0b5453..380c1c6c 100755
 -  async_exec "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libgtk-3-0/gtk-query-immodules-3.0" > "$GTK_IM_MODULE_FILE"
 +  mkdir -p "$GTK_IM_MODULE_DIR" "$GTK3_IM_MODULE_DIR"
 +  ln -sf "$SNAP"/usr/lib/"$ARCH"/gtk-2.0/2.10.0/immodules/*.so "$GTK_IM_MODULE_DIR"
-+  ln -s "$SNAP_DESKTOP_RUNTIME"/usr/lib/"$ARCH"/gtk-3.0/3.0.0/immodules/*.so "$GTK3_IM_MODULE_DIR"
++  ln -sf "$SNAP_DESKTOP_RUNTIME"/usr/lib/"$ARCH"/gtk-3.0/3.0.0/immodules/*.so "$GTK3_IM_MODULE_DIR"
 +  async_exec "$SNAP/usr/lib/$ARCH/libgtk2.0-0/gtk-query-immodules-2.0" > "$GTK_IM_MODULE_FILE"
 +  async_exec "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libgtk-3-0/gtk-query-immodules-3.0" > "$GTK3_IM_MODULE_FILE"
  fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,22 +41,26 @@ plugs:
     interface: content
     target: $SNAP/lib/gtk-2.0
     default-provider: gtk2-common-themes
+  gtk-2-themes:
+    interface: content
+    target: $SNAP/share/themes
+    default-provider: gtk2-common-themes
   gtk-3-themes:
-    default-provider: gtk-common-themes:gtk-3-themes
     interface: content
     target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
   sound-themes:
-    default-provider: gtk-common-themes:sound-themes
     interface: content
     target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
   gnome-3-28-1804:
-    default-provider: gnome-3-28-1804:gnome-3-28-1804
     interface: content
     target: $SNAP/gnome-platform
+    default-provider: gnome-3-28-1804
   icon-themes:
-    default-provider: gtk-common-themes:icon-themes
     interface: content
     target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
 
 slots:
   dbus-gimp:
@@ -80,6 +84,9 @@ environment:
   LD_LIBRARY_PATH: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$LD_LIBRARY_PATH
   PYTHONPATH: $SNAP/usr/lib/python2.7:$SNAP/usr/lib/python2.7/site-packages:$PYTHONPATH
   FINAL_BINARY: $SNAP/usr/bin/gimp
+  GTK_PATH: $SNAP/lib/gtk-2.0
+  GTK_DATA_PREFIX: $SNAP
+  XDG_DATA_DIRS: $SNAP/share:$XDG_DATA_DIRS
 
 apps:
   gimp:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,11 +37,10 @@ layout:
     bind: $SNAP/usr/share/mypaint-data
 
 plugs:
-  ## DISABLED (1 of 4) because gtk2-common-themes only available on amd64
-  # gtk-2-engines:
-  #   interface: content
-  #   target: $SNAP/lib/gtk-2.0
-  #   default-provider: gtk2-common-themes
+  gtk-2-engines:
+    interface: content
+    target: $SNAP/lib/gtk-2.0
+    default-provider: gtk2-common-themes
   gtk-3-themes:
     default-provider: gtk-common-themes:gtk-3-themes
     interface: content
@@ -138,16 +137,10 @@ parts:
   gnome-extension:
     after: [patches]
     build-packages:
-    - libgail-dev
     - libgtk-3-dev
     - libgtk2.0-dev
     stage-packages:
     - appmenu-gtk2-module
-    - gtk2-engines
-    - gtk2-engines-pixbuf
-    - libatk-adaptor
-    - libcanberra-gtk-module
-    - libgail-common
     - libgtk2.0-0
     - libgtk2.0-bin
     - unity-gtk2-module
@@ -169,10 +162,9 @@ parts:
       # Make GTK2 available via GTK_EXE_PREFIX expansion instead of GTK_PATH
       mv $SNAPCRAFT_PART_INSTALL/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gtk-2.0 \
         $SNAPCRAFT_PART_INSTALL/usr/lib/gtk-2.0
-      ## DISABLED (2 of 4) because gtk2-common-themes only available on amd64
-      # # Make GTK2 engines available from content snap via GTK_EXE_PREFIX expansion
-      # ln -sf ../../../../lib/gtk-2.0/2.10.0/engines \
-      #   $SNAPCRAFT_PART_INSTALL/usr/lib/gtk-2.0/2.10.0/
+      # Make GTK2 engines available from content snap via GTK_EXE_PREFIX expansion
+      ln -sf ../../../../lib/gtk-2.0/2.10.0/engines \
+        $SNAPCRAFT_PART_INSTALL/usr/lib/gtk-2.0/2.10.0/
 
   patches:
     source: patches
@@ -618,8 +610,7 @@ parts:
     - core18
     - gnome-3-28-1804
     - gtk-common-themes
-    ## DISABLED (3 of 4) because gtk2-common-themes only available on amd64
-    # - gtk2-common-themes
+    - gtk2-common-themes
     override-prime: |
       set -eux
       cd /snap/core18/current
@@ -628,6 +619,5 @@ parts:
       find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/{} \;
       cd /snap/gtk-common-themes/current
       find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/usr/{} \;
-      ## DISABLED (4 of 4) because gtk2-common-themes only available on amd64
-      # cd /snap/gtk2-common-themes/current/lib
-      # find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/{} \;
+      cd /snap/gtk2-common-themes/current/lib
+      find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/{} \;


### PR DESCRIPTION
This also reverts a previous commit which disabled the usage of gtk2-common-themes.  This was originally done because gtk2-common-themes was only built for amd64.  We'll soon have gtk2-common-themes for all supported architectures.