### PR TITLE
Removal of Daniel's hyperlink should occur.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,6 @@ upstream so GIMP can authoritatively publish future releases.
 
 If you have any questions, [post in the Snapcraft forum](https://forum.snapcraft.io).
 
-
-## The Snapcrafters
-
-| [![Daniel Llewellyn](http://gravatar.com/avatar/c77d9922c44ee0a34b8cabc4029b5082/?s=128)](https://github.com/diddledan/) |
-| :---: |
-| [Daniel Llewellyn](https://github.com/diddledan/) |
-
 <!-- Uncomment and modify this when you have upstream contacts
 ## Upstream
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ upstream so GIMP can authoritatively publish future releases.
 
 If you have any questions, [post in the Snapcraft forum](https://forum.snapcraft.io).
 
+## The Snapcrafters
+
+| [![Dani Llewellyn](https://gravatar.com/avatar/c77d9922c44ee0a34b8cabc4029b5082/?s=128)](https://github.com/diddledani/) |
+| :---: |
+| [Dani Llewellyn](https://github.com/diddledani/) |
+
 <!-- Uncomment and modify this when you have upstream contacts
 ## Upstream
 


### PR DESCRIPTION
Removal of Daniel's hyperlink should occur because its embedded hyperlink is not leading to anything.