### PR TITLE
Add qtwayland5 depends for gmic to work on Wayland

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -847,6 +847,7 @@ parts:
       - libtiff5
       - libxkbfile1
       - libxres1
+      - qtwayland5
       - zlib1g
       - try:
         - libfftw3-long3


### PR DESCRIPTION
Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>