### PR TITLE
Drop the deb package libheif1 and libheif-dev

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -608,7 +608,6 @@ parts:
     - libgtk-3-dev
     - libgtk2.0-dev
     - libgudev-1.0-dev
-    - libheif-dev
     - libice-dev
     - libilmbase-dev
     - libisocodes-dev
@@ -661,7 +660,6 @@ parts:
     - libglib2.0-0
     - libgpm2
     - libgs9
-    # - libheif1
     - libilmbase12
     - libjpeg-turbo8
     - libjson-glib-1.0-0


### PR DESCRIPTION
Ref: #166 

We compile libheif ourselves so including libheif-dev in build-packages causes issues.

Signed-off-by: Dani Llewellyn <dani@bowlhat.net>