### PR TITLE
Fix some missing files and inability to find others

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,8 @@ layout:
     bind: $SNAP/etc/gimp
   /etc/ld.so.cache:
     bind-file: $SNAP_DATA/etc/ld.so.cache
+  /usr/bin/gjs:
+    symlink: $SNAP/gnome-platform/usr/bin/gjs
   /usr/lib/$CRAFT_ARCH_TRIPLET/babl-0.1:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/babl-0.1
   /usr/lib/$CRAFT_ARCH_TRIPLET/gegl-0.4:
@@ -30,14 +32,12 @@ layout:
   #   bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/darktable
   /usr/lib/$CRAFT_ARCH_TRIPLET/evince/4/backends:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/evince/4/backends
-  /usr/lib/gimp:
-    bind: $SNAP/usr/lib/gimp
-  /usr/lib/python3.10:
-    bind: $SNAP/usr/lib/python3.10
   /usr/lib/gvfs:
     bind: $SNAP/usr/lib/gvfs
   /usr/lib/$CRAFT_ARCH_TRIPLET/gvfs:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/gvfs
+  /usr/lib/$CRAFT_ARCH_TRIPLET/lua:
+    symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/lua
   /usr/libexec:
     bind: $SNAP/usr/libexec
   /usr/share/color:
@@ -46,14 +46,14 @@ layout:
   #   bind: $SNAP/usr/share/darktable
   /usr/share/ghostscript:
     bind: $SNAP/usr/share/ghostscript
-  /usr/share/gimp:
-    bind: $SNAP/usr/share/gimp
   /usr/share/gvfs:
     bind: $SNAP/usr/share/gvfs
   /usr/share/lensfun:
     bind: $SNAP/usr/share/lensfun
   /usr/share/locale:
     bind: $SNAP/usr/share/locale
+  /usr/share/lua:
+    bind: $SNAP/usr/share/lua
   /usr/share/mypaint-data:
     bind: $SNAP/usr/share/mypaint-data
 
@@ -71,9 +71,11 @@ slots:
 
 environment:
   GTK_USE_PORTAL: '1'
+  GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET/gjs/girepository-1.0
   GIMP2_LOCALEDIR: $SNAP/usr/share/locale
-  LD_LIBRARY_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/blas
-  PYTHONPATH: $SNAP/usr/lib/python3.10:$SNAP/usr/lib/python3.10/site-packages:$PYTHONPATH
+  LD_LIBRARY_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/usr/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET:$SNAP/lib
+  PYTHONHOME: $SNAP/gnome-platform/usr
+  PYTHONPATH: $SNAP/gnome-platform/usr/lib/python3.10
 
 apps:
   gimp:
@@ -192,6 +194,8 @@ parts:
     - libsdl2-2.0-0
     - libtheora0
     - libv4l-0
+    - libva-drm2
+    - libva-x11-2
     - libva2
     - libvdpau1
     - libvpx7
@@ -240,10 +244,6 @@ parts:
     - git
     - meson
     - w3m
-    prime:
-    - -usr/include
-    - -usr/lib/pkgconfig
-    - -**/*.la
 
   # https://download.gimp.org/pub/gegl
   gegl:
@@ -325,39 +325,6 @@ parts:
     - libspqr2
     - libumfpack5
     - libv4l-0
-    stage:
-    - -**/*.la
-    - -etc
-    - -var/lib/ucf
-    - -usr/sbin/update-mime
-    - -usr/share/X11
-    - -usr/share/alsa
-    - -usr/share/applications
-    - -usr/share/apport
-    - -usr/share/apps
-    - -usr/share/binfmts
-    - -usr/share/bug
-    - -usr/share/debhelper
-    - -usr/share/doc
-    - -usr/share/doc-base
-    - -usr/share/fonts
-    - -usr/share/glib-2.0
-    - -usr/share/libdrm
-    - -usr/share/libthai
-    - -usr/share/lintian
-    - -usr/share/locale
-    - -usr/share/man
-    - -usr/share/menu
-    - -usr/share/mime
-    - -usr/share/perl5
-    - -usr/share/pixmaps
-    - -usr/share/pkgconfig
-    - -usr/share/python
-    - -usr/share/xml
-    prime:
-    - -usr/include
-    - -usr/lib/pkgconfig
-    - -usr/share/vala
 
   # https://aomedia.googlesource.com
   libaom:
@@ -673,15 +640,17 @@ parts:
     - --enable-check-update=no
     - --enable-gi-docgen=no
     - --enable-g-ir-doc=no
+    - --enable-debug=yes
     - --enable-default-binary=yes
+    - --enable-relocatable-bundle=yes
     build-environment:
     - to armhf:
-      - CFLAGS: -Ofast -g -pipe -mfpu=neon -flto
-      - CXXFLAGS: -Ofast -g -pipe -mfpu=neon -flto
+      - CFLAGS: -Ofast -pipe -mfpu=neon -flto
+      - CXXFLAGS: -Ofast -pipe -mfpu=neon -flto
       - LDFLAGS: -mfpu=neon -flto
     - else:
-      - CFLAGS: -Ofast -g -pipe -flto
-      - CXXFLAGS: -Ofast -g -pipe -flto
+      - CFLAGS: -Ofast -pipe -flto
+      - CXXFLAGS: -Ofast -pipe -flto
       - LDFLAGS: -flto
     - BABL_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/babl-0.1
     - GEGL_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET/gegl-0.4
@@ -719,6 +688,7 @@ parts:
     - libopenexr-dev
     - libslang2-dev
     - libsm-dev
+    - libunwind-dev
     - libwebp-dev
     - libxmu-dev
     - libxpm-dev
@@ -726,9 +696,9 @@ parts:
     - poppler-data
     - xdg-utils
     - xsltproc
-    - libunwind-dev
     stage-packages:
     # - gvfs-backends
+    - iso-codes
     - libaa1
     - libart-2.0-2
     - libbz2-1.0
@@ -741,87 +711,15 @@ parts:
     - libmng2
     - libopenexr25
     - libslang2
+    - libunwind8
     - libwebp7
     - libwebpdemux2
     - libwebpmux3
     - libxmu6
     - libxpm4
+    - lua-lgi
     - luajit
     - poppler-data
-    - libunwind8
-    stage:
-    - -**/*.la
-    - -etc/dbus-1
-    - -etc/default
-    - -etc/dictionaries-common
-    - -etc/emacs
-    - -etc/fonts
-    - -etc/glvnd
-    - -etc/gnome
-    - -etc/gss
-    - -etc/gtk-3.0
-    - -etc/init.d
-    - -etc/libblockdev
-    - -etc/libpaper.d
-    - -etc/mailcap.order
-    - -etc/mime.types
-    - -etc/rc*.d
-    - -etc/sensors3.conf
-    - -etc/systemd
-    - -etc/ucf.conf
-    - -etc/udisks2
-    - -etc/X11
-    - -sbin/cfdisk
-    - -sbin/cgdisk
-    - -sbin/fdisk
-    - -sbin/fixparts
-    - -sbin/gdisk
-    - -sbin/parted
-    - -sbin/partprobe
-    - -sbin/sfddisk
-    - -sbin/sgdisk
-    - -usr/bin/aspell*
-    - -usr/bin/dbus*
-    - -usr/bin/desktop-file-*
-    - -usr/bin/fc-*
-    - -usr/bin/gtk-update-icon-cache
-    - -usr/bin/ispell*
-    - -usr/bin/mtrace
-    - -usr/bin/rpcgen
-    - -usr/bin/run-*
-    - -usr/bin/select-default-iwrap
-    - -usr/bin/update-*-database
-    - -usr/bin/xdpyinfo
-    - -usr/bin/xdriinfo
-    - -usr/bin/xev
-    - -usr/bin/xfd
-    - -usr/bin/xfontsel
-    - -usr/bin/xkill
-    - -usr/bin/xlsatoms
-    - -usr/bin/xlsclients
-    - -usr/bin/xlsfonts
-    - -usr/bin/xmessage
-    - -usr/bin/xprop
-    - -usr/bin/xvinfo
-    - -usr/bin/xwininfo
-    - -usr/lib/aspell
-    - -usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig/libcrypt.pc
-    - -usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig/libxcrypt.pc
-    - -usr/share/doc/libjpeg*
-    - -usr/share/ghostscript
-    - -usr/share/pkgconfig/iso-codes.pc
-    - -**/iso-codes
-    - -var/cache
-    - -var/lib/aspell
-    - -var/lib/dbus
-    - -var/lib/dictionaries-common
-    - -var/lib/emacsen-common
-    - -var/lib/ispell
-    - -var/lib/systemd
-    - -var/lib/ucf
-    prime:
-    - -usr/include
-    - -usr/lib/pkgconfig
 
   # gmic:
   #   after: [appstream-glib, gexiv, gimp]
@@ -962,10 +860,14 @@ parts:
     override-prime: |
       set -eux
       for snap in "gnome-42-2204" "gtk-common-themes"; do  # List all content-snaps you're using here
-        cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" \;
+        cd "/snap/$snap/current" && \
+          find . \
+            -type f,l \
+            -not -path "./usr/share/xml/iso-codes/*" \
+            -exec rm -f "$CRAFT_PRIME/{}" \;
       done
       for CRUFT in bug lintian man; do
         rm -rf $CRAFT_PRIME/usr/share/$CRUFT
       done
       find $CRAFT_PRIME/usr/share/doc/ -type f -not -name 'copyright' -delete
-      find $CRAFT_PRIME/usr/share -type d -empty -not -path "$CRAFT_PRIME/usr/share/gimp/*" -delete
+      find $CRAFT_PRIME/usr/share -type d -empty -delete


### PR DESCRIPTION
* Add some extra layout definitions for gimp to find some platform executables and shared files
* Update the `environment:` block for runtime search paths that are missing in the platform snap's `desktop-launch` script
* Add missing `libva-drm` and `libva-x11` libraries
* Ensure gimp is built as a relocatable executable so that it can find some of its assets easier in the snap
* Move the debug symbols compiler flags to use the `configure` script's support
* Add missing `iso-codes` because gimp refuses to look for them anywhere but `$SNAP/usr/share/xml/iso-codes`
* Add missing `lua-lgi` for gimp's lua scripting capability
* Fix the cleanup part to not delete the `iso-codes` we're including in the snap directly

Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>