### PR TITLE
Update build-prs action (preview branch)

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   snapcraft-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 720
     strategy:
       matrix:
         architecture:
@@ -13,10 +14,10 @@ jobs:
         # - armhf
         - arm64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: docker/setup-qemu-action@v1
       with:
-        image: tonistiigi/binfmt@sha256:df15403e06a03c2f461c1f7938b171fda34a5849eb63a70e2a2109ed5a778bde
+        image: tonistiigi/binfmt:latest
     - uses: diddlesnaps/snapcraft-multiarch-action@v1
       id: build
       with:


### PR DESCRIPTION
* Increase the timeout to 12 hours (720 minutes) to combat the arm64 build timing out

Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>