### PR TITLE
Pick AOM release to increase arm64 build reliability

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -458,6 +458,7 @@ parts:
     after: [gegl]
     source: https://aomedia.googlesource.com/aom
     source-type: git
+    source-tag: v3.4.0
     plugin: cmake
     build-snaps: [cmake]
     build-environment:


### PR DESCRIPTION
Re-introducing the specific source release tag for AOM because it makes the arm64 build more reliable.