### PR TITLE
fix: update LD_LIBRARY_PATH for crashing python plugins

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,7 @@ slots:
 
 environment:
   GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$GI_TYPELIB_PATH
-  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas
+  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas
   # Ensure the gmic plugin can correctly locate the QT plugins
   QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
 


### PR DESCRIPTION
Currently python-based plug-ins (15 in total) are crashing with messages like the following:

```
Querying plug-in: '/snap/gimp/x2/usr/lib/x86_64-linux-gnu/gimp/3.0/plug-ins/test-file-plug-ins/test-file-plug-ins.py'
GIMP-WARNING: gimp-2.99: gimp_wire_read(): unexpected EOF
Terminating plug-in: '/snap/gimp/x2/usr/lib/x86_64-linux-gnu/gimp/3.0/plug-ins/test-file-plug-ins/test-file-plug-ins.py'
.
.
```

Specifically, the python plug-ins are seg faulting, which can be seen by shelling into the snap and running a minimum example:

```
/snap/gimp/x1$ python3
Python 3.12.3 (main, Sep 11 2024, 14:17:37) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import gi
>>> gi.require_version("Gimp", "3.0")
>>> gi.require_version("GimpUi", "3.0")
>>> gi.require_version("Gtk", "3.0")
>>> from gi.repository import Gimp
Segmentation fault (core dumped)
```

Updating the LD_LIBRARY_PATH resolves this issue by providing the correct libs (those that GIMP are built against) at runtime. 

## Snapshots after deploying the fix

* 134 plug-ins available from the plug-in browser (compared to 120 previously)

![Screenshot from 2024-11-04 15-20-20](https://github.com/user-attachments/assets/bffef22e-d8ea-4dd6-9a9d-d19d256d41de)

* Python Fu Plugin Menu

![Screenshot from 2024-11-04 16-09-00](https://github.com/user-attachments/assets/9423f071-f85e-408e-a59a-4dbf18c3a925)

* One of the Python plug-ins (Python console) launched from the GIMP menu (Filters -> Development -> Python Fu -> Python Console)

![Screenshot from 2024-11-04 16-08-39](https://github.com/user-attachments/assets/7313716d-2b4b-4f46-8a27-b753b110484a)


 