### PR TITLE
chore: gimp 2.99.19-dev -> 3.0.0-rc1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -213,54 +213,55 @@ parts:
       - mypaint-data
       - poppler-data
 
-  gmic:
-    after: [gimp]
-    plugin: nil
-    override-pull: |
-      VERSION="v.3.4.2"
-      git clone -b "$VERSION" https://github.com/GreycLab/gmic.git
-      git clone -b "$VERSION" https://github.com/GreycLab/CImg.git
-      git clone -b "$VERSION" https://github.com/c-koi/gmic-qt.git
+  # TODO(jnsgruk): Re-enable once compatibility is restored with GIMP 3.0
+  # gmic:
+  #   after: [gimp]
+  #   plugin: nil
+  #   override-pull: |
+  #     VERSION="v.3.4.2"
+  #     git clone -b "$VERSION" https://github.com/GreycLab/gmic.git
+  #     git clone -b "$VERSION" https://github.com/GreycLab/CImg.git
+  #     git clone -b "$VERSION" https://github.com/c-koi/gmic-qt.git
 
-      # Force this extra online fetch to happen during the pull phase.
-      # This build takes a long time on Launchpad, and if we wait until
-      # the build phase, by the time we get there the proxy token has
-      # expired - so force it to happen here.
-      wget -qO gmic/src/gmic_stdlib_community.h "https://gmic.eu/gmic_stdlib_community$(echo "${VERSION}" | tr -d "v.").h"
-    build-environment:
-      - QT_SELECT: qt6
-    build-packages:
-      - pkg-config
-      - qmake6-bin
-      - qt6-base-dev
-      - qt6-l10n-tools
-      - qt6-tools-dev
-      - qt6-wayland-dev
-      - qtchooser
-      - wget
-    stage-packages:
-      - libcurl4
-      - libdouble-conversion3
-      - libfftw3-bin
-      - libffi8
-      - libgraphicsmagick-q16-3
-      - libgraphicsmagick++-q16-12
-      - libjpeg-turbo8
-      - libopencv-core406t64
-      - libopencv-highgui406t64
-      - libopencv-video406t64
-      - libopenexr-3-1-30
-      - libpng16-16
-      - libqt6core6t64
-      - libqt6gui6t64
-      - libqt6network6t64
-      - libqt6widgets6t64
-      - qt6-wayland
-    override-build: |
-      qtchooser -install qt6 "$(which qmake6)" || true
-      make -C gmic/src CImg.h gmic_stdlib_community.h
-      cd gmic-qt
-      qmake HOST=gimp3
-      make
-      install -Dm 0755 $CRAFT_PART_BUILD/gmic-qt/gmic_gimp_qt \
-        $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/3.0/plug-ins/gmic_gimp_qt/gmic_gimp_qt
+  #     # Force this extra online fetch to happen during the pull phase.
+  #     # This build takes a long time on Launchpad, and if we wait until
+  #     # the build phase, by the time we get there the proxy token has
+  #     # expired - so force it to happen here.
+  #     wget -qO gmic/src/gmic_stdlib_community.h "https://gmic.eu/gmic_stdlib_community$(echo "${VERSION}" | tr -d "v.").h"
+  #   build-environment:
+  #     - QT_SELECT: qt6
+  #   build-packages:
+  #     - pkg-config
+  #     - qmake6-bin
+  #     - qt6-base-dev
+  #     - qt6-l10n-tools
+  #     - qt6-tools-dev
+  #     - qt6-wayland-dev
+  #     - qtchooser
+  #     - wget
+  #   stage-packages:
+  #     - libcurl4
+  #     - libdouble-conversion3
+  #     - libfftw3-bin
+  #     - libffi8
+  #     - libgraphicsmagick-q16-3
+  #     - libgraphicsmagick++-q16-12
+  #     - libjpeg-turbo8
+  #     - libopencv-core406t64
+  #     - libopencv-highgui406t64
+  #     - libopencv-video406t64
+  #     - libopenexr-3-1-30
+  #     - libpng16-16
+  #     - libqt6core6t64
+  #     - libqt6gui6t64
+  #     - libqt6network6t64
+  #     - libqt6widgets6t64
+  #     - qt6-wayland
+  #   override-build: |
+  #     qtchooser -install qt6 "$(which qmake6)" || true
+  #     make -C gmic/src CImg.h gmic_stdlib_community.h
+  #     cd gmic-qt
+  #     qmake HOST=gimp3
+  #     make
+  #     install -Dm 0755 $CRAFT_PART_BUILD/gmic-qt/gmic_gimp_qt \
+  #       $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/3.0/plug-ins/gmic_gimp_qt/gmic_gimp_qt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: gimp
-version: 2.99.18
+version: 3.0.0-RC1
 summary: GNU Image Manipulation Program
 description: |
   Whether you are a graphic designer, photographer, illustrator, or scientist,
@@ -40,10 +40,9 @@ environment:
 
 apps:
   gimp:
-    command: usr/bin/gimp-2.99
+    command: usr/bin/gimp
     extensions: [gnome]
     desktop: usr/share/applications/gimp.desktop
-
     common-id: org.gimp.GIMP
     slots:
       - dbus-gimp
@@ -59,8 +58,7 @@ parts:
   babl:
     plugin: meson
     source: https://gitlab.gnome.org/GNOME/babl.git
-    # TODO: replace this with a tag on next release
-    source-commit: c5f97c86224a473cc3fea231f17adef84580f2cc
+    source-tag: BABL_0_1_110
     meson-parameters:
       - --prefix=/usr
       - --buildtype=release
@@ -72,8 +70,7 @@ parts:
     after:
       - babl
     source: https://gitlab.gnome.org/GNOME/gegl.git
-    # TODO: replace this with a tag on next release
-    source-commit: d540df2ad27c06891271d96247f915073b042a3e
+    source-tag: GEGL_0_4_50
     plugin: meson
     meson-parameters:
       - --prefix=/usr
@@ -129,12 +126,10 @@ parts:
       - gegl
     plugin: meson
     source: https://gitlab.gnome.org/GNOME/gimp.git
-    source-commit: a92388c433da868c5d84b14362f7a8151d287ad7
     override-pull: |
-      # TODO: remove `craftctl default` and use this when 2.99.19 actually releases
-      #   tag="$(echo "GIMP_${SNAPCRAFT_PROJECT_VERSION}" | tr "." "_")"
-      #   git clone -b "$tag" https://gitlab.gnome.org/GNOME/gimp.git
-      craftctl default
+      tag="$(echo "GIMP_${SNAPCRAFT_PROJECT_VERSION}" | tr "." "_"  | tr "-" "_")"
+      git clone -b "$tag" https://gitlab.gnome.org/GNOME/gimp.git "$CRAFT_PART_SRC"
+      git submodule update --init
       sed -i 's|^Icon=.*|Icon=/usr/share/icons/hicolor/256x256/apps/gimp.png|' desktop/gimp.desktop.in.in
     meson-parameters:
       - --prefix=/usr
@@ -222,7 +217,7 @@ parts:
     after: [gimp]
     plugin: nil
     override-pull: |
-      VERSION=v.3.4.2
+      VERSION="v.3.4.2"
       git clone -b "$VERSION" https://github.com/GreycLab/gmic.git
       git clone -b "$VERSION" https://github.com/GreycLab/CImg.git
       git clone -b "$VERSION" https://github.com/c-koi/gmic-qt.git


### PR DESCRIPTION
Bumps GIMP to the first 3.0 release candidate.

This also disables gmic for now, since there has been a backward incompatible change which is yet to be resolved in the gmic upstream repo. 

While disabling gmic is a shame, I'd rather focus on having a working 3.0 on release day, and we can add plugins/extras as they release/update.