### PR TITLE
build: workarounds for gitlab instability and librsvg search path bug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,7 +78,7 @@ parts:
       - -Ddocs=false
       - -Dworkshop=true
     build-environment:
-      - C_INCLUDE_PATH: /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/pkgconfig/../../../include/librsvg-2.0:${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}
+      - C_INCLUDE_PATH: /snap/gnome-46-2404-sdk/current/usr/include/librsvg-2.0:${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}
     build-packages:
       - ffmpeg
       - libexiv2-dev
@@ -149,7 +149,7 @@ parts:
       - GEGL_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gegl-0.4
       - GI_TYPELIB_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$GI_TYPELIB_PATH
       - LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
-      - C_INCLUDE_PATH: /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/pkgconfig/../../../include/librsvg-2.0:${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}
+      - C_INCLUDE_PATH: /snap/gnome-46-2404-sdk/current/usr/include/librsvg-2.0:${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}
     build-packages:
       - automake
       - intltool

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,7 +57,7 @@ apps:
 parts:
   babl:
     plugin: meson
-    source: https://gitlab.gnome.org/GNOME/babl.git
+    source: https://github.com/GNOME/babl.git
     source-tag: BABL_0_1_110
     meson-parameters:
       - --prefix=/usr
@@ -69,7 +69,7 @@ parts:
   gegl:
     after:
       - babl
-    source: https://gitlab.gnome.org/GNOME/gegl.git
+    source: https://github.com/GNOME/gegl.git
     source-tag: GEGL_0_4_50
     plugin: meson
     meson-parameters:
@@ -77,6 +77,8 @@ parts:
       - --buildtype=release
       - -Ddocs=false
       - -Dworkshop=true
+    build-environment:
+      - C_INCLUDE_PATH: /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/pkgconfig/../../../include/librsvg-2.0:${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}
     build-packages:
       - ffmpeg
       - libexiv2-dev
@@ -125,10 +127,10 @@ parts:
       - babl
       - gegl
     plugin: meson
-    source: https://gitlab.gnome.org/GNOME/gimp.git
+    source: https://github.com/GNOME/gimp.git
     override-pull: |
       tag="$(echo "GIMP_${SNAPCRAFT_PROJECT_VERSION}" | tr "." "_"  | tr "-" "_")"
-      git clone -b "$tag" https://gitlab.gnome.org/GNOME/gimp.git "$CRAFT_PART_SRC"
+      git clone -b "$tag" https://github.com/GNOME/gimp.git "$CRAFT_PART_SRC"
       git submodule update --init
       sed -i 's|^Icon=.*|Icon=/usr/share/icons/hicolor/256x256/apps/gimp.png|' desktop/gimp.desktop.in.in
     meson-parameters:
@@ -147,6 +149,7 @@ parts:
       - GEGL_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gegl-0.4
       - GI_TYPELIB_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$GI_TYPELIB_PATH
       - LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      - C_INCLUDE_PATH: /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/pkgconfig/../../../include/librsvg-2.0:${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}
     build-packages:
       - automake
       - intltool


### PR DESCRIPTION
The current build is failing for a few different reasons outlined below. I spent quite a bit of time fighting these issues so wanted to share as it may help unblock others. Since these are workarounds, I leave it to @jnsgruk and others to decide whether to actually merge this into `preview`,  to simply leave this PR open for reference, or something else. :)

## Issues and their workarounds  

* Intermittent instability of the GNOME gitlab instance, causing frequent failures in the pull stage for each part. It looks like these are known issues with the GNOME gitlab infrastructure and there is [scheduled maintenance on Dec 4](https://discourse.gnome.org/t/scheduled-maintenance-gitlab-gitlab-pages-04th-of-december-2024-at-2-pm-utc/25271) to migrate their infra to AWS. To overcome this issue I updated the source URL to the mirrors for each repo hosted at github.com/GNOME.
* Recent versions (e.g. 2.59.1) of `librsvg` introduced a variable `${pcfiledir}` in `librsvg-2.0.pc` it distributes for `pkgconfig`. The `gnome-46-2404-sdk` snap now ships version 2.59.1 of `librsvg` and snapcraft is unable to correctly process `${pcfiledir}` as reported recently in https://github.com/canonical/snapcraft/issues/5158. This results in the following error during the `gimp` build:

```
2024-12-02 21:58:23.329 :: 2024-12-02 21:58:22.753 :: ../src/operations/external/svg-load.c:44:10: fatal error: librsvg/rsvg.h: No such file or directory
```

The build logs also show the failing command with the incorrect path to the `librsvg` headers:

```
cc ... -I/snap/gnome-46-2404-sdk/current/snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/pkgconfig/../../../include/librsvg-2.0 ... -o operations/external/svg-load.so.p/svg-load.c.o -c ../src/operations/external/svg-load.c
```

To workaround this second issue I hard-coded the correct path to the `librsvg` headers in the `build-environment` section in the parts where it is required.