### PR TITLE
build: pull gimp submodules from github due to gitlab infra instability

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,6 +131,7 @@ parts:
     override-pull: |
       tag="$(echo "GIMP_${SNAPCRAFT_PROJECT_VERSION}" | tr "." "_"  | tr "-" "_")"
       git clone -b "$tag" https://github.com/GNOME/gimp.git "$CRAFT_PART_SRC"
+      sed -i "s|gitlab.gnome.org|github.com|" "$CRAFT_PART_SRC"/.gitmodules
       git submodule update --init
       sed -i 's|^Icon=.*|Icon=/usr/share/icons/hicolor/256x256/apps/gimp.png|' desktop/gimp.desktop.in.in
     meson-parameters:


### PR DESCRIPTION
Follow up on https://github.com/snapcrafters/gimp/pull/300 to also pull gimp's submodules from github rather than gitlab as gitlab infra is under maintenance.

I tested the build locally and verified from the logs that the submodules are now being pulled from github:

```
2024-12-04 14:34:24.011 :: 2024-12-04 14:30:13.292 :: + sed -i 's|gitlab.gnome.org|github.com|' /root/parts/gimp/src/.gitmodules
2024-12-04 14:34:24.011 :: 2024-12-04 14:30:13.306 :: + git submodule update --init
2024-12-04 14:34:24.011 :: 2024-12-04 14:30:13.343 :: Submodule 'gimp-data' (https://github.com/GNOME/gimp-data.git) registered for path 'gimp-data'
```