### PR TITLE
feature: integrate OpenVINO AI plugins

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: ["preview"]
+    branches: ["2.99-openvino"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-to-candidate.yaml
+++ b/.github/workflows/release-to-candidate.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   # Run the workflow each time new commits are pushed to the candidate branch.
   push:
-    branches: ["preview"]
+    branches: ["2.99-openvino"]
   workflow_dispatch:
 
 concurrency:
@@ -27,20 +27,20 @@ jobs:
         uses: snapcrafters/ci/get-architectures@main
 
   release:
-    name: 🚢 Release to preview/candidate
+    name: 🚢 Release to 2.99-openvino/candidate
     needs: get-architectures
     runs-on: self-hosted
     timeout-minutes: 1440
-    environment: "Preview Candidate Branch"
+    environment: "2.99 OpenVino Candidate Branch"
     strategy:
       matrix:
         architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}
     steps:
-      - name: 🚢 Release to preview/candidate
+      - name: 🚢 Release to 2.99-openvino/candidate
         uses: snapcrafters/ci/release-to-candidate@main
         with:
           architecture: ${{ matrix.architecture }}
-          channel: preview/candidate
+          channel: 2.99-openvino/candidate
           launchpad-token: ${{ secrets.LP_BUILD_SECRET }}
           repo-token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           store-token: ${{ secrets.SNAP_STORE_CANDIDATE }}
@@ -48,7 +48,7 @@ jobs:
   call-for-testing:
     name: 📣 Create call for testing
     needs: [release, get-architectures]
-    environment: "Preview Candidate Branch"
+    environment: "2.99 OpenVino Candidate Branch"
     runs-on: ubuntu-latest
     outputs:
       issue-number: ${{ steps.issue.outputs.issue-number }}
@@ -58,20 +58,20 @@ jobs:
         uses: snapcrafters/ci/call-for-testing@main
         with:
           architectures: ${{ needs.get-architectures.outputs.architectures }}
-          channel: preview/candidate
+          channel: 2.99-openvino/candidate
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          promotion-channel: preview/stable
+          promotion-channel: 2.99-openvino/stable
 
   screenshots:
     name: 📸 Gather screenshots
     needs: call-for-testing
-    environment: "Preview Candidate Branch"
+    environment: "2.99 OpenVino Candidate Branch"
     runs-on: self-hosted
     steps:
       - name: 📸 Gather screenshots
         uses: snapcrafters/ci/get-screenshots@main
         with:
-          channel: preview/candidate
+          channel: 2.99-openvino/candidate
           issue-number: ${{ needs.call-for-testing.outputs.issue-number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           screenshots-token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,62 @@ Now that your git metadata has been updated you are ready to create a bugfix bra
 6. Someone from the team will review the open pull request and either merge it or start a discussion with you with additional changes or clarification needed.
 7. Once the pull request has been merged into the stable branch, a GitHub action will rebuild the snap using your changes and publish it to the [Snap Store](https://snapcraft.io/gimp) into the `candidate` channel. After sufficient testing of the snap from the candidate channel, one of the maintainers or administrators will promote the snap to the stable branch in the Snap Store.
 
+## OpenVINO AI Plugins
+
+This snap contains support for AI plugins running on Intel hardware (CPU, GPU, and NPU) using Intel's OpenVINO AI inference library. In order to use these plugins, please follow these steps:
+
+1. Build and install the OpenVINO-enabled GIMP snap locally as it is not currently published:
+
+    ```shell
+    cd gimp
+    snapcraft
+    sudo snap install --dangerous ./gimp_2.99.16_amd64.snap
+    ```
+
+    **TODO**: publish the snap under a new track in the store (e.g. `sudo snap install gimp --channel=openvino-ai-plugins/beta`).
+
+2. Install the content provider snaps that provide runtime libraries and the GIMP plugins:
+
+    ```shell
+    sudo snap install intel-npu-driver --beta # for NPU support
+    sudo snap install openvino-toolkit-2404 --beta
+    sudo snap install openvino-ai-plugins-gimp --edge
+    ```
+
+3. Connect snap interfaces:
+
+    ```shell
+    sudo snap connect gimp:intel-npu intel-npu-driver:intel-npu
+    sudo snap connect gimp:npu-libs intel-npu-driver:npu-libs
+    sudo snap connect gimp:openvino-libs openvino-toolkit-2404:openvino-libs
+    sudo snap connect gimp:openvino-ai-plugins-gimp-libs openvino-ai-plugins-gimp:openvino-ai-plugins-gimp-libs
+    ```
+
+    **TODO**: request autoconnections from the Snap Store.
+
+4. (Optional) Install stable diffusion models. Models for the other plugins are relatively small so are built into the snap, while the stable diffusion models are each on the order of GBs and therefore downloaded to a user's home directory via a `model-setup` command line tool.
+
+    First connect the snap interfaces for the `model-setup` application:
+
+    ```shell
+    sudo snap connect openvino-ai-plugins-gimp:home
+    sudo snap connect openvino-ai-plugins-gimp:openvino-libs openvino-toolkit-2404:openvino-libs
+    sudo snap connect openvino-ai-plugins-gimp:intel-npu intel-npu-driver:intel-npu
+    sudo snap connect openvino-ai-plugins-gimp:npu-libs intel-npu-driver:npu-libs
+    ```
+
+    Now run the application:
+
+    ```shell
+    openvino-ai-plugins-gimp.model-setup
+    ```
+
+    Note this will install models in your home directory at `~/openvino-ai-plugins-gimp`. To adjust the path set the `GIMP_OPENVINO_MODELS_PATH` shell variable to a different non-hidden location in your home directory.
+
+    **TODO**: request autoconnections from the Snap Store.
+
+5. Run `gimp` like normal. Instructions for using the OpenVINO AI plugins within GIMP can be found in the [upstream GitHub repo](https://github.com/intel/openvino-ai-plugins-gimp).
+
 ## Maintainers
 
 -   [@lucyllewy](https://github.com/lucyllewy/)

--- a/README.md
+++ b/README.md
@@ -82,22 +82,29 @@ Now that your git metadata has been updated you are ready to create a bugfix bra
 
 This snap contains support for AI plugins running on Intel hardware (CPU, GPU, and NPU) using Intel's OpenVINO AI inference library. In order to use these plugins, please follow these steps:
 
-1. Build and install the OpenVINO-enabled GIMP snap locally as it is not currently published:
+
+1. Install the plugin dependencies, which provide runtime libraries and the GIMP plugins:
+
+    ```shell
+    sudo snap install intel-npu-driver --beta # for NPU support
+    sudo snap install openvino-toolkit-2404 --beta
+    sudo snap install openvino-ai-plugins-gimp --beta
+    ```
+
+2. Install the OpenVINO-enabled GIMP snap:
+
+    If you want to try the latest published version from the Snap Store use the following command:
+
+    ```shell
+    sudo snap install gimp --channel=2.99-openvino/beta
+    ```
+
+    If instead you wish to build the snap yourself for local development, use the following commands:
 
     ```shell
     cd gimp
     snapcraft
     sudo snap install --dangerous ./gimp_2.99.16_amd64.snap
-    ```
-
-    **TODO**: publish the snap under a new track in the store (e.g. `sudo snap install gimp --channel=openvino-ai-plugins/beta`).
-
-2. Install the content provider snaps that provide runtime libraries and the GIMP plugins:
-
-    ```shell
-    sudo snap install intel-npu-driver --beta # for NPU support
-    sudo snap install openvino-toolkit-2404 --beta
-    sudo snap install openvino-ai-plugins-gimp --edge
     ```
 
 3. Connect snap interfaces:
@@ -108,8 +115,6 @@ This snap contains support for AI plugins running on Intel hardware (CPU, GPU, a
     sudo snap connect gimp:openvino-libs openvino-toolkit-2404:openvino-libs
     sudo snap connect gimp:openvino-ai-plugins-gimp-libs openvino-ai-plugins-gimp:openvino-ai-plugins-gimp-libs
     ```
-
-    **TODO**: request autoconnections from the Snap Store.
 
 4. (Optional) Install stable diffusion models. Models for the other plugins are relatively small so are built into the snap, while the stable diffusion models are each on the order of GBs and therefore downloaded to a user's home directory via a `model-setup` command line tool.
 
@@ -129,8 +134,6 @@ This snap contains support for AI plugins running on Intel hardware (CPU, GPU, a
     ```
 
     Note this will install models in your home directory at `~/openvino-ai-plugins-gimp`. To adjust the path set the `GIMP_OPENVINO_MODELS_PATH` shell variable to a different non-hidden location in your home directory.
-
-    **TODO**: request autoconnections from the Snap Store.
 
 5. Run `gimp` like normal. Instructions for using the OpenVINO AI plugins within GIMP can be found in the [upstream GitHub repo](https://github.com/intel/openvino-ai-plugins-gimp).
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: gimp
-version: 3.0.0-RC1
+version: 2.99.16
 summary: GNU Image Manipulation Program
 description: |
   Whether you are a graphic designer, photographer, illustrator, or scientist,
@@ -32,15 +32,33 @@ slots:
     bus: session
     name: org.gimp.GIMP.UI
 
+plugs:
+  intel-npu:
+    interface: custom-device
+    custom-device: intel-npu-device
+  npu-libs:
+    interface: content
+    content: npu-libs-2404
+    target: $SNAP/npu-libs
+  openvino-libs:
+    interface: content
+    content: openvino-libs-2404
+    target: $SNAP/openvino
+  openvino-ai-plugins-gimp-libs:
+    interface: content
+    content: openvino-ai-plugins-gimp-2404
+    target: $SNAP/openvino-ai-plugins-gimp
+
 environment:
   GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$GI_TYPELIB_PATH
-  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas
+  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/npu-libs
   # Ensure the gmic plugin can correctly locate the QT plugins
   QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
 
 apps:
   gimp:
-    command: usr/bin/gimp
+    command: usr/bin/gimp-2.99
+    command-chain: ["command-chain/openvino-launch", "command-chain/openvino-ai-plugins-gimp-launch"]
     extensions: [gnome]
     desktop: usr/share/applications/gimp.desktop
     common-id: org.gimp.GIMP
@@ -53,6 +71,10 @@ apps:
       - network
       - removable-media
       - unity7
+      - intel-npu
+      - npu-libs
+      - openvino-libs
+      - openvino-ai-plugins-gimp-libs
 
 parts:
   babl:
@@ -131,8 +153,8 @@ parts:
     override-pull: |
       tag="$(echo "GIMP_${SNAPCRAFT_PROJECT_VERSION}" | tr "." "_"  | tr "-" "_")"
       git clone -b "$tag" https://github.com/GNOME/gimp.git "$CRAFT_PART_SRC"
-      sed -i "s|gitlab.gnome.org|github.com|" "$CRAFT_PART_SRC"/.gitmodules
-      git submodule update --init
+      #sed -i "s|gitlab.gnome.org|github.com|" "$CRAFT_PART_SRC"/.gitmodules
+      #git submodule update --init
       sed -i 's|^Icon=.*|Icon=/usr/share/icons/hicolor/256x256/apps/gimp.png|' desktop/gimp.desktop.in.in
     meson-parameters:
       - --prefix=/usr
@@ -216,6 +238,36 @@ parts:
       - mypaint-brushes
       - mypaint-data
       - poppler-data
+    override-stage: |
+      # fix gimp python interpreters file
+      cat <<EOF > $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      python=/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/usr/bin/python3
+      python3=/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/usr/bin/python3
+      /usr/bin/python=/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/usr/bin/python3
+      /usr/bin/python3=/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/usr/bin/python3
+      :Python:E::py::python3:
+      EOF
+      # update gimp's plugin search path so it will pick up plugins mounted over snapd's content interface
+      current_path=$(grep "# (plug-in-path" ${CRAFT_PART_INSTALL}/etc/gimp/2.99/gimprc | cut -d '"' -f2)
+      add_dir=/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/openvino-ai-plugins-gimp/gimp-plugins
+      echo "(plug-in-path \"${current_path}:${add_dir}\")" >> $CRAFT_PART_INSTALL/etc/gimp/2.99/gimprc
+      craftctl default
+
+  command-chain-openvino:
+    plugin: dump
+    source-type: git
+    source: https://github.com/canonical/openvino-toolkit-snap.git
+    source-branch: openvino-toolkit-2404
+    stage:
+      - command-chain/openvino-launch
+
+  command-chain-openvino-ai-plugins-gimp:
+    plugin: dump
+    source-type: git
+    source: https://github.com/canonical/openvino-ai-plugins-gimp-snap.git
+    source-branch: frenchwr/create-snap # TODO: update to stable branch
+    stage:
+      - command-chain/openvino-ai-plugins-gimp-launch
 
   # TODO(jnsgruk): Re-enable once compatibility is restored with GIMP 3.0
   # gmic:


### PR DESCRIPTION
## Background on plugins

This PR integrates OpenVINO AI plugins from from a [repo maintained by Intel](https://github.com/intel/openvino-ai-plugins-gimp). The plugins include stable diffusion, semantic segmentation, and super resolution, and use Intel's AI inference library OpenVINO which supports accelerators like Intel GPUs and NPUs (neural processing units). The NPUs are built into Intel's line of Core Ultra chips that are present in many new laptop and desktop devices, so the hardware support for the plugins, while not universal, is expected to reach a large number of users. The plugins do not yet support GIMP v3, although it's on the roadmap.

## Technical details

The primary changes include integrating with multiple content producer snaps to minimize the maintenance burden on the GIMP snap itself. In summary:

* Add a new plug for `openvino-ai-plugins-gimp` snap (see [PR here](https://github.com/canonical/openvino-ai-plugins-gimp-snap/pull/1) for background) and add a `command-chain` script from this repo to set the runtime environment for GIMP. An update to GIMP's plug-in search path allows these plugins to be used over this interface.
* Add a new plug for `openvino-toolkit-2404` snap ([repo](https://github.com/canonical/openvino-toolkit-snap)) and add a `command-chain` script from this repo to set the runtime environment for GIMP.
* Add a new plug for accessing the Intel NPU char device node on the host over the `custom-device` snapd interface. The slot is provided by [the `intel-npu-driver` snap](https://github.com/canonical/intel-npu-driver-snap/).
* Add a new plug for mounting the NPU runtime libs from [the `intel-npu-driver` snap](https://github.com/canonical/intel-npu-driver-snap/).
* Add `override-stage` section to the gimp part of the snap to update the plugin search path and to fix GIMP's python interpreters file, which was pointing at a python interpreter that does not exist inside the snap.

## Testing

I've tested on a remote machine equipped with an Intel CPU, GPU, and NPU. I have verified that all three AI plugins function on the different hardware device types, with the GPU and NPU providing acceleration.

