### PR TITLE
feature: switch to personal-files interface as a less intrusive location for models

### DIFF
--- a/.github/plug-declaration.json
+++ b/.github/plug-declaration.json
@@ -1,0 +1,3 @@
+{
+    "personal-files": { "allow-installation": "true" }
+}

--- a/README.md
+++ b/README.md
@@ -114,26 +114,16 @@ This snap contains support for AI plugins running on Intel hardware (CPU, GPU, a
     sudo snap connect gimp:npu-libs intel-npu-driver:npu-libs
     sudo snap connect gimp:openvino-libs openvino-toolkit-2404:openvino-libs
     sudo snap connect gimp:openvino-ai-plugins-gimp-libs openvino-ai-plugins-gimp:openvino-ai-plugins-gimp-libs
+    sudo snap connect gimp:dot-local-share-openvino-ai-plugins-gimp
     ```
 
-4. (Optional) Install stable diffusion models. Models for the other plugins are relatively small so are built into the snap, while the stable diffusion models are each on the order of GBs and therefore downloaded to a user's home directory via a `model-setup` command line tool.
-
-    First connect the snap interfaces for the `model-setup` application:
-
-    ```shell
-    sudo snap connect openvino-ai-plugins-gimp:home
-    sudo snap connect openvino-ai-plugins-gimp:openvino-libs openvino-toolkit-2404:openvino-libs
-    sudo snap connect openvino-ai-plugins-gimp:intel-npu intel-npu-driver:intel-npu
-    sudo snap connect openvino-ai-plugins-gimp:npu-libs intel-npu-driver:npu-libs
-    ```
-
-    Now run the application:
+4. (Optional) Install stable diffusion models. Models for the other plugins are relatively small so are built into the snap, while the stable diffusion models are each on the order of GBs and therefore downloaded to a user's home directory at `~/.local/share/openvino-ai-plugins-gimp` via one of two methods: a `model-setup` command-line tool or from within the GIMP application. To run the interactive command-line tool:
 
     ```shell
     openvino-ai-plugins-gimp.model-setup
     ```
 
-    Note this will install models in your home directory at `~/openvino-ai-plugins-gimp`. To adjust the path set the `GIMP_OPENVINO_MODELS_PATH` shell variable to a different non-hidden location in your home directory.
+    Alternatively, users may download models from within GIMP by clicking "Model" in the top-left of the stable diffusion dialog window (Layer -> OpenVINO-AI-Plugins -> Stable Diffusion).
 
 5. Run `gimp` like normal. Instructions for using the OpenVINO AI plugins within GIMP can be found in the [upstream GitHub repo](https://github.com/intel/openvino-ai-plugins-gimp).
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,6 +48,10 @@ plugs:
     interface: content
     content: openvino-ai-plugins-gimp-2404
     target: $SNAP/openvino-ai-plugins-gimp
+  dot-local-share-openvino-ai-plugins-gimp:
+    interface: personal-files
+    write:
+      - $HOME/.local/share/openvino-ai-plugins-gimp
 
 environment:
   GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$GI_TYPELIB_PATH
@@ -75,6 +79,7 @@ apps:
       - npu-libs
       - openvino-libs
       - openvino-ai-plugins-gimp-libs
+      - dot-local-share-openvino-ai-plugins-gimp
 
 parts:
   babl:
@@ -265,7 +270,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-ai-plugins-gimp-snap.git
-    source-branch: frenchwr/create-snap # TODO: update to stable branch
+    source-branch: main
     stage:
       - command-chain/openvino-ai-plugins-gimp-launch
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -262,7 +262,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-branch: openvino-toolkit-2404
+    source-tag: 2024.5.0-0
     stage:
       - command-chain/openvino-launch
 
@@ -270,7 +270,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-ai-plugins-gimp-snap.git
-    source-branch: main
+    source-commit: 7d20266d73ba25cd49aae55f0a2157911fb6bc75  # TODO: update to tagged release once upstream branch merged
     stage:
       - command-chain/openvino-ai-plugins-gimp-launch
 


### PR DESCRIPTION
The primary change here is to switch from installing stable diffusion models at `~/openvino-ai-plugins-gimp` to a hidden directory at `~/.local/share/openvino-ai-plugins-gimp`. This requires adding the `personal-files` interface to the new snap (which will likely trigger a manual review of the `gimp` snap as it did for the `openvino-ai-plugins-gimp` snap). See [this forum post](https://forum.snapcraft.io/t/interface-autoconnections-request-for-openvino-ai-plugins-gimp/44275) for more discussion.

Other changes:

* Remove manual interface connections for `openvino-ai-plugins-gimp` snap as those now autoconnect :partying_face: 
* Switch to `main` branch for fetching command-chain script