### PR TITLE
fix: minor plug-in and extension errors from logs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,9 @@ environment:
   LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/npu-libs
   # Ensure the gmic plugin can correctly locate the QT plugins
   QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
+  GIMP3_LOCALEDIR: $SNAP/usr/share/locale
+  LUA_PATH: $SNAP/usr/share/lua/5.1/?.lua;$SNAP/usr/share/lua/5.1/lgi/?.lua;$SNAP/usr/share/lua/5.1/lgi/override/?.lua
+  LUA_CPATH: $SNAP/usr/lib/x86_64-linux-gnu/lua/5.1/?.so
 
 apps:
   gimp:
@@ -245,17 +248,17 @@ parts:
       - poppler-data
     override-stage: |
       # fix gimp python interpreters file
-      cat <<EOF > $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/interpreters/pygimp.interp
-      python=/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/usr/bin/python3
-      python3=/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/usr/bin/python3
-      /usr/bin/python=/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/usr/bin/python3
-      /usr/bin/python3=/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/usr/bin/python3
+      cat <<EOF > ${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/gimp/2.99/interpreters/pygimp.interp
+      python=/usr/bin/python3
+      python3=/usr/bin/python3
+      /usr/bin/python=/usr/bin/python3
+      /usr/bin/python3=/usr/bin/python3
       :Python:E::py::python3:
       EOF
       # update gimp's plugin search path so it will pick up plugins mounted over snapd's content interface
       current_path=$(grep "# (plug-in-path" ${CRAFT_PART_INSTALL}/etc/gimp/2.99/gimprc | cut -d '"' -f2)
-      add_dir=/snap/"${SNAPCRAFT_PROJECT_NAME}"/current/openvino-ai-plugins-gimp/gimp-plugins
-      echo "(plug-in-path \"${current_path}:${add_dir}\")" >> $CRAFT_PART_INSTALL/etc/gimp/2.99/gimprc
+      add_dir=/snap/${SNAPCRAFT_PROJECT_NAME}/current/openvino-ai-plugins-gimp/gimp-plugins
+      echo "(plug-in-path \"${current_path}:${add_dir}\")" >> ${CRAFT_PART_INSTALL}/etc/gimp/2.99/gimprc
       craftctl default
 
   command-chain-openvino:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,8 +59,10 @@ environment:
   # Ensure the gmic plugin can correctly locate the QT plugins
   QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
   GIMP3_LOCALEDIR: $SNAP/usr/share/locale
-  LUA_PATH: $SNAP/usr/share/lua/5.1/?.lua;$SNAP/usr/share/lua/5.1/lgi/?.lua;$SNAP/usr/share/lua/5.1/lgi/override/?.lua
-  LUA_CPATH: $SNAP/usr/lib/x86_64-linux-gnu/lua/5.1/?.so
+  # Lua goat exercise considered unstable upstream: https://gitlab.gnome.org/GNOME/gimp/-/commit/78665ca3723f723ac313fdaeef5b62d41ab6b48d
+  # The extension will fail on GIMP startup but commenting these lines avoids the risk of a nasty crash loop
+  #LUA_PATH: $SNAP/usr/share/lua/5.1/?.lua;$SNAP/usr/share/lua/5.1/lgi/?.lua;$SNAP/usr/share/lua/5.1/lgi/override/?.lua
+  #LUA_CPATH: $SNAP/usr/lib/x86_64-linux-gnu/lua/5.1/?.so
 
 apps:
   gimp:


### PR DESCRIPTION
This cleans up a handful of minor issues I've noticed from the logs while running GIMP in verbose mode:

* Set locale directory for GIMP as plug-ins are failing to find this at runtime
* Set lua environment vars so the lua goat exercise extension works correctly (previously it was crashing)
* Update paths in GIMP's python interpreters file. Previously at startup GIMP was complaining that the previous paths were invalid (which they were), although Python plug-ins continued to work normally. I went ahead and fixed the interpreters file to use `python3` from the core24 snap at `/usr/bin/python3` as this is the interpreter shown from running `which python3` while shelled into the snap, and GIMP no longer complains about the paths being invalid.

A few side notes:

* The `preview` branch would also benefit from these changes. The OpenVINO plugins were updated upstream last week to support GIMP 3.0-RC2 which means we should be able to merge the `2.99-openvino` branch back into `preview` sooner than I expected. I hope to test in the next few weeks.
* Last week I published `arm64` builds of `openvino-toolkit-2404` and `openvino-ai-plugins-gimp`. I haven't tested them thoroughly but at least they are now available for those on arm machines wishing to test the plugins.