### PR TITLE
chore: bump versions of command-chain scripts for openvino ai plugins support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -267,7 +267,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-tag: 2024.5.0-0
+    source-tag: 2024.6.0-1
     stage:
       - command-chain/openvino-launch
 
@@ -275,7 +275,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-ai-plugins-gimp-snap.git
-    source-commit: 7d20266d73ba25cd49aae55f0a2157911fb6bc75  # TODO: update to tagged release once upstream branch merged
+    source-tag: v2.99-R3.1-1
     stage:
       - command-chain/openvino-ai-plugins-gimp-launch
 


### PR DESCRIPTION
This bumps versions for a few `command-chain` scripts to bring in minor changes and bug fixes for the OpenVINO AI plugins.

Side note: the upstream [OpenVINO plugins now support GIMP 3.0 RC2](https://github.com/intel/openvino-ai-plugins-gimp/releases/tag/3.0.0). I will soon start testing against the `preview` branch.