### PR TITLE
Adding plugs for themes.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,6 +97,8 @@ apps:
       - openvino-libs
       - openvino-ai-plugins-gimp-libs
       - dot-local-share-openvino-ai-plugins-gimp
+      - gtk-3-themes
+      - icon-themes
 
 parts:
   babl:


### PR DESCRIPTION
When I install Gimp via Snapcraft, it doesn't connect to Snap themes in general, only with gtk-common-themes, it would be good to add these plugs to see if that changes.