### PR TITLE
Bump versions for OpenVINO plugins, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,54 @@ snap install gimp
 
 <p align="center">Published for <img src="https://raw.githubusercontent.com/anythingcodes/slack-emoji-for-techies/gh-pages/emoji/tux.png" align="top" width="24" /> with :gift_heart: by Snapcrafters</p>
 
+## OpenVINO™ AI Plugins
+
+> [!IMPORTANT]
+> These plugins are only supported on Intel hardware. The stable diffusion plugin requires an Intel GPU (integrated or discrete) and/or Intel NPU. The super resolution and semantic segmentation plugins will run on an Intel CPU, GPU, or NPU.
+
+This snap contains support for AI plugins using Intel's OpenVINO AI inference library. In order to use these plugins, please follow these steps:
+
+1. **Install the plugins and their dependencies**:
+
+    ```shell
+    sudo snap install intel-npu-driver # for NPU support
+    sudo snap install openvino-toolkit-2404
+    sudo snap install openvino-ai-plugins-gimp
+    ```
+
+2. **(Optional) Enable Intel NPU and GPU acceleration**:
+
+    If you are running on a machine (e.g. a laptop or desktop containing an Intel Core Ultra processor) equipped with an Intel neural processing unit (NPU) or graphics processing unit (GPU), ensure you have permissions to use these devices by adding yourself to the `render` Unix group:
+
+    ```shell
+    sudo usermod -a -G render $USER
+    ```
+
+    You need to log out and log back for this change to take effect.
+
+    Next, ensure that the devices have read and write permissions set on the group level:
+
+    ```shell
+    sudo chown root:render /dev/accel/accel*
+    sudo chmod g+rw /dev/accel/accel*
+    sudo chown root:render /dev/dri/render*
+    sudo chmod g+rw /dev/dri/render*
+    ```
+
+3. **(Optional) Install stable diffusion models**:
+
+    Models for the super resolution and semantic segmentation plugins are relatively small and therefore built into the snap, while the stable diffusion models are each on the order of GBs and therefore downloaded to a user's home directory at `~/.local/share/openvino-ai-plugins-gimp` via one of two methods: a `model-setup` command-line tool or from within the GIMP application. To run the interactive command-line tool:
+
+    ```shell
+    openvino-ai-plugins-gimp.model-setup
+    ```
+
+    Alternatively, users may download models from within GIMP by clicking "Model" in the top-left of the stable diffusion dialog window (Layer -> OpenVINO-AI-Plugins -> Stable Diffusion).
+
+4. **Run `gimp` like normal**:
+
+    Instructions for using the OpenVINO AI plugins within GIMP can be found in the [upstream GitHub repo](https://github.com/intel/openvino-ai-plugins-gimp).
+
 ## How to contribute to this snap
 
 Thanks for your interest! Below you find instructions to help you contribute to this snap.
@@ -78,58 +126,10 @@ Now that your git metadata has been updated you are ready to create a bugfix bra
 6. Someone from the team will review the open pull request and either merge it or start a discussion with you with additional changes or clarification needed.
 7. Once the pull request has been merged into the stable branch, a GitHub action will rebuild the snap using your changes and publish it to the [Snap Store](https://snapcraft.io/gimp) into the `candidate` channel. After sufficient testing of the snap from the candidate channel, one of the maintainers or administrators will promote the snap to the stable branch in the Snap Store.
 
-## OpenVINO™ AI Plugins
-
-> [!IMPORTANT]
-> These plugins are only supported on Intel hardware. The stable diffusion plugin requires an Intel GPU (integrated or discrete) and/or Intel NPU. The super resolution and semantic segmentation plugins will run on an Intel CPU, GPU, or NPU.
-
-This snap contains support for AI plugins using Intel's OpenVINO AI inference library. In order to use these plugins, please follow these steps:
-
-
-1. **Install the plugins and their dependencies**:
-
-    ```shell
-    sudo snap install intel-npu-driver --beta # for NPU support
-    sudo snap install openvino-toolkit-2404 --beta
-    sudo snap install openvino-ai-plugins-gimp --beta
-    ```
-
-2. **(Optional) Enable Intel NPU and GPU acceleration**:
-
-    If you are running on a machine (e.g. a laptop or desktop containing an Intel Core Ultra processor) equipped with an Intel neural processing unit (NPU) or graphics processing unit (GPU), ensure you have permissions to use these devices by adding yourself to the `render` Unix group:
-
-    ```shell
-    sudo usermod -a -G render $USER
-    ```
-
-    You need to log out and log back for this change to take effect.
-
-    Next, ensure that the devices have read and write permissions set on the group level:
-
-    ```shell
-    sudo chown root:render /dev/accel/accel*
-    sudo chmod g+rw /dev/accel/accel*
-    sudo chown root:render /dev/dri/render*
-    sudo chmod g+rw /dev/dri/render*
-    ```
-
-3. **(Optional) Install stable diffusion models**:
-
-    Models for the super resolution and semantic segmentation plugins are relatively small and therefore built into the snap, while the stable diffusion models are each on the order of GBs and therefore downloaded to a user's home directory at `~/.local/share/openvino-ai-plugins-gimp` via one of two methods: a `model-setup` command-line tool or from within the GIMP application. To run the interactive command-line tool:
-
-    ```shell
-    openvino-ai-plugins-gimp.model-setup
-    ```
-
-    Alternatively, users may download models from within GIMP by clicking "Model" in the top-left of the stable diffusion dialog window (Layer -> OpenVINO-AI-Plugins -> Stable Diffusion).
-
-4. **Run `gimp` like normal**:
-
-    Instructions for using the OpenVINO AI plugins within GIMP can be found in the [upstream GitHub repo](https://github.com/intel/openvino-ai-plugins-gimp).
-
 ## Maintainers
 
 -   [@lucyllewy](https://github.com/lucyllewy/)
+-   [@frenchwr](https://github.com/frenchwr/)
 
 ## License
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -317,7 +317,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-tag: 2024.6.0-4
+    source-tag: 2025.2.0-amd64-rev32
     stage:
       - command-chain/openvino-launch
     override-stage: |
@@ -330,7 +330,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-ai-plugins-gimp-snap.git
-    source-branch: 3.0.0-2
+    source-branch: frenchwr/bump-to-version-3.1.2
     stage:
       - command-chain/openvino-ai-plugins-gimp-launch
     override-stage: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,9 @@ description: |
   further enhance your productivity with GIMP thanks to many customization
   options and 3rd party plugins.
 
+  ⚡️ **OpenVINO AI Plugins**: if you are running on Intel hardware, follow
+  [this guide](https://github.com/snapcrafters/gimp/blob/candidate/README.md#openvino-ai-plugins) to enable AI features in GIMP!
+
 website: https://gimp.org/
 contact: https://github.com/snapcrafters/gimp/issues
 issues: https://gitlab.gnome.org/GNOME/gimp/-/issues
@@ -317,7 +320,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-tag: 2025.2.0-amd64-rev32
+    source-tag: 2025.2.0-amd64-rev34
     stage:
       - command-chain/openvino-launch
     override-stage: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,7 +69,7 @@ plugs:
 
 environment:
   GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$GI_TYPELIB_PATH
-  LD_LIBRARY_PATH: $SNAP/usr/local/lib:$SNAP/usr/local/lib/libheif:$SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/npu-libs
+  LD_LIBRARY_PATH: $SNAP/usr/local/lib:$SNAP/usr/local/lib/libheif:$SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/npu-libs
   # Ensure the gmic plugin can correctly locate the QT plugins
   QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
   GIMP3_LOCALEDIR: $SNAP/usr/share/locale

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,8 @@ layout:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gegl-0.4
   /usr/share/locale:
     bind: $SNAP/usr/share/locale
+  /etc/gitconfig:
+    bind-file: $SNAP_DATA/etc/gitconfig
 
 slots:
   dbus-gimp:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -333,7 +333,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-ai-plugins-gimp-snap.git
-    source-branch: frenchwr/bump-to-version-3.1.2
+    source-tag: 3.1.2-rev39
     stage:
       - command-chain/openvino-ai-plugins-gimp-launch
     override-stage: |


### PR DESCRIPTION
We recently released new versions of the `openvino-tookit-2404` and `openvino-ai-plugins-gimp` snaps (in `stable/edge` only for now). This PR updates GIMP to pull from these new versions, while also making a few updates to the docs in the README.md and the description field within `snapcraft.yaml`.

I've tested this build of GIMP locally against both of the updated OpenVINO snaps.