### PR TITLE
feat: implement generic interface for plugins

### DIFF
--- a/.github/plug-declaration.json
+++ b/.github/plug-declaration.json
@@ -1,3 +1,0 @@
-{
-    "personal-files": { "allow-installation": "true" }
-}

--- a/README.md
+++ b/README.md
@@ -24,53 +24,26 @@ snap install gimp
 
 <p align="center">Published for <img src="https://raw.githubusercontent.com/anythingcodes/slack-emoji-for-techies/gh-pages/emoji/tux.png" align="top" width="24" /> with :gift_heart: by Snapcrafters</p>
 
-## OpenVINO™ AI Plugins
+## Third-Party Plugins
 
-> [!IMPORTANT]
-> These plugins are only supported on Intel hardware. The stable diffusion plugin requires an Intel GPU (integrated or discrete) and/or Intel NPU. The super resolution and semantic segmentation plugins will run on an Intel CPU, GPU, or NPU.
+This snap contains a generic plug for supporting third-party plugins over snapd's content interface. To integrate such plugins, a content producer snap must provide a slot of the form:
 
-This snap contains support for AI plugins using Intel's OpenVINO AI inference library. In order to use these plugins, please follow these steps:
+```yaml
+slots:
+  gimp-plugins:
+    interface: content
+    content: gimp-plugins
+    source:
+      read:
+        - $SNAP/plugin-a
+        - $SNAP/plugin-b
+        - $SNAP/wrappers-for-my-plugins
+        - $SNAP/libs-for-my-plugins
+```
 
-1. **Install the plugins and their dependencies**:
+where `plugin-a` and `plugin-b` provide code for running two distinct plugins, and libraries for the plugins are installed in `libs-for-my-plugins`. Additionally, the `gimp` snap will `source` any `.env` files it finds in directories named with the `wrappers-` prefix. This provides a method for running setup commands (e.g. exporting environment variables) for the plugins each time GIMP is launched.
 
-    ```shell
-    sudo snap install intel-npu-driver # for NPU support
-    sudo snap install openvino-toolkit-2404
-    sudo snap install openvino-ai-plugins-gimp
-    ```
-
-2. **(Optional) Enable Intel NPU and GPU acceleration**:
-
-    If you are running on a machine (e.g. a laptop or desktop containing an Intel Core Ultra processor) equipped with an Intel neural processing unit (NPU) or graphics processing unit (GPU), ensure you have permissions to use these devices by adding yourself to the `render` Unix group:
-
-    ```shell
-    sudo usermod -a -G render $USER
-    ```
-
-    You need to log out and log back for this change to take effect.
-
-    Next, ensure that the devices have read and write permissions set on the group level:
-
-    ```shell
-    sudo chown root:render /dev/accel/accel*
-    sudo chmod g+rw /dev/accel/accel*
-    sudo chown root:render /dev/dri/render*
-    sudo chmod g+rw /dev/dri/render*
-    ```
-
-3. **(Optional) Install stable diffusion models**:
-
-    Models for the super resolution and semantic segmentation plugins are relatively small and therefore built into the snap, while the stable diffusion models are each on the order of GBs and therefore downloaded to a user's home directory at `~/.local/share/openvino-ai-plugins-gimp` via one of two methods: a `model-setup` command-line tool or from within the GIMP application. To run the interactive command-line tool:
-
-    ```shell
-    openvino-ai-plugins-gimp.model-setup
-    ```
-
-    Alternatively, users may download models from within GIMP by clicking "Model" in the top-left of the stable diffusion dialog window (Layer -> OpenVINO-AI-Plugins -> Stable Diffusion).
-
-4. **Run `gimp` like normal**:
-
-    Instructions for using the OpenVINO AI plugins within GIMP can be found in the [upstream GitHub repo](https://github.com/intel/openvino-ai-plugins-gimp).
+An example for the QT G'MIC plugins for GIMP can be found [here](https://github.com/canonical/gimp-plugins-gmic-snap).
 
 ## How to contribute to this snap
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,17 @@ slots:
       read:
         - $SNAP/plugin-a
         - $SNAP/plugin-b
-        - $SNAP/wrappers-for-my-plugins
+        - $SNAP/my-plugins.conf
         - $SNAP/libs-for-my-plugins
 ```
 
-where `plugin-a` and `plugin-b` provide code for running two distinct plugins, and libraries for the plugins are installed in `libs-for-my-plugins`. Additionally, the `gimp` snap will `source` any `.env` files it finds in directories named with the `wrappers-` prefix. This provides a method for running setup commands (e.g. exporting environment variables) for the plugins each time GIMP is launched.
+where `plugin-a` and `plugin-b` provide code for running two distinct plugins, and libraries for the plugins are installed in `libs-for-my-plugins`. Additionally, the `gimp` snap supports appending directories to `LD_LIBRARY_PATH` so it can find `.so` files shipped by content producer snaps that are connected to the `gimp-plugins` interface. It does so by searching for files named `add-ld-library-path` inside directories named with a `.conf` suffix (`my-plugins.conf` in the example above). The `add-ld-library-path` file should list one directory per line, with paths relative to top-level directory of the `gimp-plugins` content interface (`$SNAP/gimp-plugins`). For example, in the example above the `add-ld-library-path` file could be as simple as:
+
+```
+libs-for-my-plugins
+```
+
+This assumes that all .so files required by the plugins are shipped inside this single directory.
 
 An example for the QT G'MIC plugins for GIMP can be found [here](https://github.com/canonical/gimp-plugins-gmic-snap).
 

--- a/command-chain/enable-plugins
+++ b/command-chain/enable-plugins
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Set environment for third-party plugins.
+#
+
+shopt -s nullglob
+
+for wrapper in "${SNAP}"/gimp-plugins/wrappers-*/*.env; do
+  source "${wrapper}"
+done
+exec "$@"

--- a/command-chain/enable-plugins
+++ b/command-chain/enable-plugins
@@ -1,11 +1,21 @@
 #!/bin/bash
 #
-# Set environment for third-party plugins.
+# Set LD_LIBRARY_PATH for third-party plugins.
+#
+# Each third-party plugin snap may provide a
+# add-ld-library-path file so GIMP can find the
+# plugin's .so's. The file should provide a path
+# relative to ${SNAP}/gimp-plugins, which is the
+# mount point for the GIMP snap's generic content
+# interface plug.
 #
 
 shopt -s nullglob
 
-for wrapper in "${SNAP}"/gimp-plugins/wrappers-*/*.env; do
-  source "${wrapper}"
+for path_file in "${SNAP}"/gimp-plugins/*.conf/add-ld-library-path; do
+  while IFS= read -r path || [ -n "${path}" ]; do
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${SNAP}/gimp-plugins/${path}"
+  done < "${path_file}"
 done
+
 exec "$@"

--- a/command-chain/enable-plugins
+++ b/command-chain/enable-plugins
@@ -14,7 +14,7 @@ shopt -s nullglob
 
 for path_file in "${SNAP}"/gimp-plugins/*.conf/add-ld-library-path; do
   while IFS= read -r path || [ -n "${path}" ]; do
-    export LD_LIBRARY_PATH="${SNAP}/gimp-plugins/${path}:${LD_LIBRARY_PATH}"
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${SNAP}/gimp-plugins/${path}"
   done < "${path_file}"
 done
 

--- a/command-chain/enable-plugins
+++ b/command-chain/enable-plugins
@@ -14,7 +14,7 @@ shopt -s nullglob
 
 for path_file in "${SNAP}"/gimp-plugins/*.conf/add-ld-library-path; do
   while IFS= read -r path || [ -n "${path}" ]; do
-    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${SNAP}/gimp-plugins/${path}"
+    export LD_LIBRARY_PATH="${SNAP}/gimp-plugins/${path}:${LD_LIBRARY_PATH}"
   done < "${path_file}"
 done
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,7 +58,7 @@ plugs:
 
 environment:
   GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$GI_TYPELIB_PATH
-  LD_LIBRARY_PATH: $SNAP/usr/local/lib:$SNAP/usr/local/lib/libheif:$SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas
+  LD_LIBRARY_PATH: $SNAP/usr/local/lib:$SNAP/usr/local/lib/libheif:$SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/npu-libs
   GIMP3_LOCALEDIR: $SNAP/usr/share/locale
   # Lua goat exercise considered unstable upstream: https://gitlab.gnome.org/GNOME/gimp/-/commit/78665ca3723f723ac313fdaeef5b62d41ab6b48d
   # The extension will fail on GIMP startup but commenting these lines avoids the risk of a nasty crash loop

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,10 +6,6 @@ description: |
   GIMP provides you with sophisticated tools to get your job done. You can
   further enhance your productivity with GIMP thanks to many customization
   options and 3rd party plugins.
-
-  ⚡️ **OpenVINO AI Plugins**: if you are running on Intel hardware, follow
-  [this guide](https://github.com/snapcrafters/gimp/blob/candidate/README.md#openvino-ai-plugins) to enable AI features in GIMP!
-
 website: https://gimp.org/
 contact: https://github.com/snapcrafters/gimp/issues
 issues: https://gitlab.gnome.org/GNOME/gimp/-/issues
@@ -61,20 +57,18 @@ plugs:
     interface: content
     content: openvino-libs-2404
     target: $SNAP/openvino
-  openvino-ai-plugins-gimp-libs:
-    interface: content
-    content: openvino-ai-plugins-gimp-2404
-    target: $SNAP/openvino-ai-plugins-gimp
   dot-local-share-openvino-ai-plugins-gimp:
     interface: personal-files
     write:
       - $HOME/.local/share/openvino-ai-plugins-gimp
+  gimp-plugins:
+    interface: content
+    content: gimp-plugins
+    target: $SNAP/gimp-plugins
 
 environment:
   GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$GI_TYPELIB_PATH
-  LD_LIBRARY_PATH: $SNAP/usr/local/lib:$SNAP/usr/local/lib/libheif:$SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/npu-libs
-  # Ensure the gmic plugin can correctly locate the QT plugins
-  QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
+  LD_LIBRARY_PATH: $SNAP/usr/local/lib:$SNAP/usr/local/lib/libheif:$SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas
   GIMP3_LOCALEDIR: $SNAP/usr/share/locale
   # Lua goat exercise considered unstable upstream: https://gitlab.gnome.org/GNOME/gimp/-/commit/78665ca3723f723ac313fdaeef5b62d41ab6b48d
   # The extension will fail on GIMP startup but commenting these lines avoids the risk of a nasty crash loop
@@ -85,11 +79,7 @@ environment:
 apps:
   gimp:
     command: usr/bin/gimp
-    command-chain:
-      [
-        "command-chain/openvino-launch",
-        "command-chain/openvino-ai-plugins-gimp-launch",
-      ]
+    command-chain: [command-chain/enable-plugins]
     extensions: [gnome]
     desktop: usr/share/applications/gimp.desktop
     common-id: org.gimp.GIMP
@@ -107,10 +97,8 @@ apps:
       - removable-media
       - unity7
       - intel-npu
-      - npu-libs
-      - openvino-libs
-      - openvino-ai-plugins-gimp-libs
       - dot-local-share-openvino-ai-plugins-gimp
+      - gimp-plugins
 
 parts:
   babl:
@@ -312,95 +300,18 @@ parts:
       EOF
       # update gimp's plugin search path so it will pick up plugins mounted over snapd's content interface
       current_path=$(grep "# (plug-in-path" ${CRAFT_PART_INSTALL}/etc/gimp/3.0/gimprc | cut -d '"' -f2)
-      add_dir=/snap/${SNAPCRAFT_PROJECT_NAME}/current/openvino-ai-plugins-gimp/gimp-plugins
+      add_dir=/snap/${SNAPCRAFT_PROJECT_NAME}/current/gimp-plugins
       echo "(plug-in-path \"${current_path}:${add_dir}\")" >> ${CRAFT_PART_INSTALL}/etc/gimp/3.0/gimprc
       craftctl default
 
-  command-chain-openvino:
+  command-chain-plugins:
     plugin: dump
-    source-type: git
-    source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-tag: 2025.2.0-amd64-rev34
-    stage:
-      - command-chain/openvino-launch
-    override-stage: |
-      if [ $(uname -m) != "x86_64" ]; then
-        echo 'exec "$@"' > ${CRAFT_PART_INSTALL}/command-chain/openvino-launch
-      fi
-      craftctl default
-
-  command-chain-openvino-ai-plugins-gimp:
-    plugin: dump
-    source-type: git
-    source: https://github.com/canonical/openvino-ai-plugins-gimp-snap.git
-    source-tag: 3.1.2-rev39
-    stage:
-      - command-chain/openvino-ai-plugins-gimp-launch
-    override-stage: |
-      if [ $(uname -m) != "x86_64" ]; then
-        echo 'exec "$@"' > ${CRAFT_PART_INSTALL}/command-chain/openvino-ai-plugins-gimp-launch
-      fi
-      craftctl default
-
-  gmic:
-    after: [gimp]
-    plugin: dump
-    source: https://gmic.eu/files/source/gmic_3.6.1.tar.gz
-    build-environment:
-      - QT_SELECT: qt6
-    build-packages:
-      - cmake
-      - pkg-config
-      - qt6-base-dev
-      - qt6-l10n-tools
-      - qt6-tools-dev
-      - qt6-wayland-dev
-      - qtchooser
-      - wget
-    stage-packages:
-      - libcurl4
-      - libdouble-conversion3
-      - libfftw3-double3
-      - libffi8
-      - libgraphicsmagick-q16-3
-      - libgraphicsmagick++-q16-12
-      - libjpeg-turbo8
-      - libopencv-core406t64
-      - libopencv-highgui406t64
-      - libopencv-video406t64
-      - libopenexr-3-1-30
-      - libpng16-16
-      - libqt6core6t64
-      - libqt6gui6t64
-      - libqt6network6t64
-      - libqt6widgets6t64
-      - qt6-wayland
-    override-build: |
-      qtchooser -install qt6 "$(which qmake6)" || true
-      make -C src CImg.h gmic_stdlib_community.h
-
-      cd gmic-qt
-      # The CMakeLists.txt file hard-codes a minimum QT6 version of 6.5.0, which is not available
-      # in Noble. Testing confirms that things seem to work fine on the version in Noble (6.4.2).
-      sed -i "s|set(MIN_QT_VERSION 6.5.0)|set(MIN_QT_VERSION 6.4.0)|g" CMakeLists.txt
-
-      mkdir build
-      cd build
-      cmake \
-        -DGMIC_QT_HOST=gimp3 \
-        -DGMIC_PATH=$CRAFT_PART_SRC/src \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DENABLE_SYSTEM_GMIC=OFF \
-        -DBUILD_WITH_QT6=ON \
-        ..
-
-      make
-
-      install -Dm 0755 $CRAFT_PART_BUILD/gmic-qt/build/gmic_gimp_qt \
-        $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/3.0/plug-ins/gmic_gimp_qt/gmic_gimp_qt
+    source: command-chain/
+    organize:
+      enable-plugins: command-chain/enable-plugins
 
   cleanup:
-    after: [gmic]
+    after: [gimp]
     source: https://github.com/canonical/gpu-snap.git
     plugin: dump
     override-prime: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,6 +97,8 @@ apps:
       - removable-media
       - unity7
       - intel-npu
+      - npu-libs
+      - openvino-libs
       - dot-local-share-openvino-ai-plugins-gimp
       - gimp-plugins
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,8 +32,6 @@ layout:
     bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gegl-0.4
   /usr/share/locale:
     bind: $SNAP/usr/share/locale
-  /etc/gitconfig:
-    bind-file: $SNAP_DATA/etc/gitconfig
 
 slots:
   dbus-gimp:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,14 +53,6 @@ plugs:
     interface: content
     content: npu-libs-2404
     target: $SNAP/npu-libs
-  openvino-libs:
-    interface: content
-    content: openvino-libs-2404
-    target: $SNAP/openvino
-  dot-local-share-openvino-ai-plugins-gimp:
-    interface: personal-files
-    write:
-      - $HOME/.local/share/openvino-ai-plugins-gimp
   gimp-plugins:
     interface: content
     content: gimp-plugins
@@ -98,8 +90,6 @@ apps:
       - unity7
       - intel-npu
       - npu-libs
-      - openvino-libs
-      - dot-local-share-openvino-ai-plugins-gimp
       - gimp-plugins
 
 parts:


### PR DESCRIPTION
This PR is motivated by the request in https://github.com/snapcrafters/gimp/issues/447 for the upstream GIMP packaging team to take over ownership of this snap.

# What has changed

* Qt G'MIC part removed from snap and migrated to a [standalone snap](https://github.com/canonical/gimp-plugins-gmic-snap)
* OpenVINO plug removed from snap
* Generic plug introduced that supports connecting to multiple slots and mounts their content at `$SNAP/gimp-plugins`
* OpenVINO command chain scripts removed from snap
* Generic command chain script introduced that supports loading wrapper scripts from content snaps, which is helpful for running setup commands (e.g. exporting environment variables)
* OpenVINO plugin docs removed from README and snapcraft.yaml
* Generic plug docs added to README

# What has not changed

* Multiple plug definitions needed for supporting OpenVINO plugins. Unfortunately these cannot be delegated to the `openvino-ai-plugins-gimp` snap as GIMP itself needs access to the host resources or libs provided by these plugs.

# Testing

I have tested on my laptop with the following commands.

```
sudo snap install --dangerous ./gimp_3.0.4_amd64.snap 
sudo snap install openvino-toolkit-2404 --channel latest/edge
sudo snap install gimp-plugins-gmic --channel latest/edge
sudo snap connect gimp:gimp-plugins gimp-plugins-gmic:gimp-plugins
sudo snap install openvino-ai-plugins-gimp --channel latest/edge
sudo snap connect gimp:gimp-plugins openvino-ai-plugins-gimp:gimp-plugins
sudo snap connect gimp:dot-local-share-openvino-ai-plugins-gimp
```

Note the last command is only needed because the GIMP snap was built and installed locally. Normally this would auto-connect when installed from the Snap Store. We could also pursue auto-connections for the `gimp-plugins-gmic` and `openvino-ai-plugins-gimp` snaps.

* Screenshot showing OpenVINO's stable diffusion plugin in action:

<img width="1513" height="1306" alt="Screenshot from 2025-09-05 11-26-11" src="https://github.com/user-attachments/assets/dcfa1286-9df9-4eac-b03e-e80cdacc2455" />

* Screenshot showing Qt G'MIC in action, editing the image resulting from the stable diffusion plugin

<img width="1534" height="1872" alt="Screenshot from 2025-09-05 11-27-32" src="https://github.com/user-attachments/assets/36d6d589-29b5-43d5-ba1c-3bdae684d72b" />


# Related work

* [Qt G'MIC plugins snap](https://github.com/canonical/gimp-plugins-gmic-snap)
* https://github.com/canonical/openvino-toolkit-snap/pull/24
* https://github.com/canonical/openvino-ai-plugins-gimp-snap/pull/18